### PR TITLE
feat: Add video mime type support (增加视频类型支持)

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -16,6 +16,5 @@ jobs:
         uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
-      - run: dart format --output=none --set-exit-if-changed .
       - run: dart analyze lib    
       - run: dart test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 # Avoid committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## 1.4.0
+
+- Feat: Add [videoMimeType] and [videoMimeTypeEnum] properties.
+
 ## 1.3.0
 
 - Feat: Add callback for [Mvimg] class.

--- a/lib/mvimg.dart
+++ b/lib/mvimg.dart
@@ -46,5 +46,7 @@
 /// ```
 library mvimg;
 
+export 'src/mime_type.dart';
 export 'src/mvimg_base.dart';
+
 export 'package:buff/buff.dart';

--- a/lib/src/mime_type.dart
+++ b/lib/src/mime_type.dart
@@ -1,0 +1,86 @@
+/// The mime types utils for motion photo
+class MvimgMimeTypes {
+  static const String _jpeg = 'image/jpeg';
+  static const String _heic = 'image/heic';
+  static const String _avif = 'image/avif';
+  static const String _mp4 = 'video/mp4';
+  static const String _quicktime = 'video/quicktime';
+
+  /// All type for motion photo
+  static const Set<String> all = {
+    _jpeg,
+    _heic,
+    _avif,
+    _mp4,
+    _quicktime,
+  };
+
+  /// Check if the mime type is supported
+  static bool isSupported(String mime) => all.contains(mime);
+
+  /// Check if the video mime type is supported
+  static bool isVideoSupported(String mime) => [
+        _mp4,
+        _quicktime,
+      ].contains(mime);
+
+  /// Get the mime type by enum
+  static String mimeTypeToString(MvimgMimeType type) {
+    switch (type) {
+      case MvimgMimeType.jpeg:
+        return _jpeg;
+      case MvimgMimeType.heic:
+        return _heic;
+      case MvimgMimeType.avif:
+        return _avif;
+      case MvimgMimeType.mp4:
+        return _mp4;
+      case MvimgMimeType.quicktime:
+        return _quicktime;
+      default:
+        throw Exception('Unknown mime type');
+    }
+  }
+
+  /// Get the enum by mime type
+  static MvimgMimeType stringToMimeType(String mime) {
+    switch (mime) {
+      case _jpeg:
+        return MvimgMimeType.jpeg;
+      case _heic:
+        return MvimgMimeType.heic;
+      case _avif:
+        return MvimgMimeType.avif;
+      case _mp4:
+        return MvimgMimeType.mp4;
+      case _quicktime:
+        return MvimgMimeType.quicktime;
+      default:
+        throw Exception('Unknown mime type');
+    }
+  }
+}
+
+/// The mime type of motion photo
+enum MvimgMimeType {
+  /// The mime type of jpeg image
+  jpeg,
+
+  /// The mime type of heic image
+  heic,
+
+  /// The mime type of avif image
+  avif,
+
+  /// The mime type of mp4 video
+  mp4,
+
+  /// The mime type of quicktime video
+  quicktime,
+}
+
+/// Extension for [MvimgMimeType]
+extension MvimgMimeTypeExtension on MvimgMimeType {
+  /// Get the mime type by enum
+  String get mimeType => MvimgMimeTypes.mimeTypeToString(this);
+}

--- a/lib/src/mvimg_base.dart
+++ b/lib/src/mvimg_base.dart
@@ -4,6 +4,8 @@ import 'package:buff/buff.dart';
 import 'package:collection/collection.dart';
 import 'package:xml/xml.dart';
 
+import 'mime_type.dart';
+
 class _Range {
   final int start;
   final int end;
@@ -75,6 +77,17 @@ class Mvimg {
   ///
   /// The xap is a xml file that contains the metadata of the motion photo file.
   _Range? _xapRange;
+
+  /// The mime type of the video.
+  String? _videoMimeType;
+
+  /// The mime type of the video.
+  MvimgMimeType? get videoMimeType {
+    if (_videoMimeType == null) {
+      return null;
+    }
+    return MvimgMimeTypes.stringToMimeType(_videoMimeType!);
+  }
 
   void setCallback(MvImgCallback callback) {
     this.callback = callback;
@@ -183,7 +196,11 @@ class Mvimg {
             final container = item.firstElementChild;
             final mimeType = container?.getAttribute('Item:Mime');
 
-            if (mimeType == 'video/mp4') {
+            if (mimeType == null) {
+              continue;
+            }
+
+            if (MvimgMimeTypes.isVideoSupported(mimeType)) {
               final length = container?.getAttribute('Item:Length');
 
               if (length == null) {
@@ -192,6 +209,7 @@ class Mvimg {
 
               final videoOffsetInt = int.parse(length);
               _videoRange = _Range(fileLength - videoOffsetInt, fileLength);
+              _videoMimeType = mimeType;
               return;
             }
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mvimg
 description: A library to split mvimg(android motion video) file.
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/caijinglong/mvimg
 
 environment:

--- a/test/mvimg_test.dart
+++ b/test/mvimg_test.dart
@@ -115,6 +115,45 @@ void main() {
       });
     }
   });
+
+  group('Test for MvimgMimeTypes', () {
+    test('Test isSupported method', () {
+      expect(MvimgMimeTypes.isSupported('image/jpeg'), isTrue);
+      expect(MvimgMimeTypes.isSupported('image/heic'), isTrue);
+      expect(MvimgMimeTypes.isSupported('image/avif'), isTrue);
+      expect(MvimgMimeTypes.isSupported('video/mp4'), isTrue);
+      expect(MvimgMimeTypes.isSupported('video/quicktime'), isTrue);
+      expect(MvimgMimeTypes.isSupported('image/png'), isFalse);
+      expect(MvimgMimeTypes.isSupported('video/webm'), isFalse);
+      expect(MvimgMimeTypes.isSupported(''), isFalse);
+    });
+
+    test('Test mimeTypeToString method', () {
+      expect(MvimgMimeTypes.mimeTypeToString(MvimgMimeType.jpeg), equals('image/jpeg'));
+      expect(MvimgMimeTypes.mimeTypeToString(MvimgMimeType.heic), equals('image/heic'));
+      expect(MvimgMimeTypes.mimeTypeToString(MvimgMimeType.avif), equals('image/avif'));
+      expect(MvimgMimeTypes.mimeTypeToString(MvimgMimeType.mp4), equals('video/mp4'));
+      expect(MvimgMimeTypes.mimeTypeToString(MvimgMimeType.quicktime), equals('video/quicktime'));
+    });
+
+    test('Test stringToMimeType method', () {
+      expect(MvimgMimeTypes.stringToMimeType('image/jpeg'), equals(MvimgMimeType.jpeg));
+      expect(MvimgMimeTypes.stringToMimeType('image/heic'), equals(MvimgMimeType.heic));
+      expect(MvimgMimeTypes.stringToMimeType('image/avif'), equals(MvimgMimeType.avif));
+      expect(MvimgMimeTypes.stringToMimeType('video/mp4'), equals(MvimgMimeType.mp4));
+      expect(MvimgMimeTypes.stringToMimeType('video/quicktime'), equals(MvimgMimeType.quicktime));
+      
+      expect(() => MvimgMimeTypes.stringToMimeType('image/png'), throwsException);
+    });
+
+    test('Test MvimgMimeType extension', () {
+      expect(MvimgMimeType.jpeg.mimeType, equals('image/jpeg'));
+      expect(MvimgMimeType.heic.mimeType, equals('image/heic'));
+      expect(MvimgMimeType.avif.mimeType, equals('image/avif'));
+      expect(MvimgMimeType.mp4.mimeType, equals('video/mp4'));
+      expect(MvimgMimeType.quicktime.mimeType, equals('video/quicktime'));
+    });
+  });
 }
 
 // assets/split/test.MP.jpg:

--- a/test/performance_test.dart
+++ b/test/performance_test.dart
@@ -66,16 +66,18 @@ void main() {
     });
 
     test('XAP Metadata Reading Performance Test (XAP 元数据读取性能测试)', () {
-      final mvimg = Mvimg(BufferInput.memory(testData));
-      mvimg.decode();
-
       final stopwatch = Stopwatch()..start();
 
       for (var i = 0; i < 100; i++) {
+        final mvimg = Mvimg(BufferInput.memory(testData));
+        mvimg.decode();
+
         if (mvimg.isMvimg()) {
           final xapBytes = mvimg.getXapBytes();
           expect(xapBytes.length, greaterThan(0));
         }
+
+        mvimg.dispose();
       }
 
       stopwatch.stop();
@@ -87,8 +89,6 @@ void main() {
       expect(stopwatch.elapsedMilliseconds, lessThan(1000),
           reason:
               '100 XAP reading operations should complete within 1 second (100次 XAP 读取操作应在1秒内完成)');
-
-      mvimg.dispose();
     });
 
     final testOutputFileList = <File>[];


### PR DESCRIPTION
- Add `videoMimeType` and `videoMimeTypeEnum` properties to `Mvimg` class (在 `Mvimg` 类中增加了 `videoMimeType` 和 `videoMimeTypeEnum` 属性)
- Add `MvimgMimeType` enum and `MvimgMimeTypes` util class (增加了 `MvimgMimeType` 枚举和 `MvimgMimeTypes` 工具类)
- Update `CHANGELOG.md` to include the new feature (更新了 `CHANGELOG.md` 以包含新特性)
- Update `pubspec.yaml` to version 1.4.0 (更新 `pubspec.yaml` 文件版本至 1.4.0)
- Added `mime_type.dart` (新增 `mime_type.dart` 文件)